### PR TITLE
Add CLI command to describe topics

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -64,8 +66,10 @@ func createTopic() *cobra.Command {
 }
 
 func createSigningKey() *cobra.Command {
-	return &cobra.Command{
-		Use:   "signing-key",
+	var jsonOut bool
+
+	cmd := &cobra.Command{
+		Use:   "signing-key [flags]",
 		Short: "Create a new signing key pair",
 		Long:  "This command creates a new signing key pair for this client to use when producing messages",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -79,10 +83,19 @@ func createSigningKey() *cobra.Command {
 				return err
 			}
 
+			if jsonOut {
+				return json.NewEncoder(os.Stdout).Encode(keyPair)
+			}
+
 			fmt.Printf("Keys below are base64 encoded, they should be provided to the server decoded.\n\n")
 			fmt.Printf("Public key:\t%s\n", base64.StdEncoding.EncodeToString(keyPair.PublicKey))
 			fmt.Printf("Private key:\t%s\n", base64.StdEncoding.EncodeToString(keyPair.PrivateKey))
 			return nil
 		},
 	}
+
+	flags := cmd.PersistentFlags()
+	flags.BoolVar(&jsonOut, "json", false, "Output signing key in JSON format")
+
+	return cmd
 }

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// Describe returns a command for describing various server resources.
+func Describe() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "describe",
+		Short: "Describe server resources (topics, etc.)",
+		Long:  "This command is the parent command for describing server resources",
+	}
+
+	cmd.AddCommand(
+		describeTopic(),
+	)
+
+	return cmd
+}
+
+func describeTopic() *cobra.Command {
+	var jsonOut bool
+
+	cmd := &cobra.Command{
+		Use:   "topic [flags] <name>",
+		Short: "Describe a topics",
+		Long:  "This command returns information about a single topic",
+		Args:  cobra.ExactValidArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := loadClient(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			topic, err := client.Topic(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+
+			if jsonOut {
+				return json.NewEncoder(os.Stdout).Encode(topic)
+			}
+
+			fmt.Println("Name:", topic.Name)
+			fmt.Println("Message Retention:", topic.MessageRetentionPeriod.String())
+			fmt.Println("Consumer Retention:", topic.ConsumerRetentionPeriod.String())
+			fmt.Println("Require Verified Messages:", topic.RequireVerifiedMessages)
+
+			return nil
+		},
+	}
+
+	flags := cmd.PersistentFlags()
+	flags.BoolVar(&jsonOut, "json", false, "Output topic information in JSON format")
+
+	return cmd
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -27,7 +27,7 @@ func listTopics() *cobra.Command {
 	var jsonOut bool
 
 	cmd := &cobra.Command{
-		Use:   "topics",
+		Use:   "topics [flags]",
 		Short: "List all topics",
 		Long:  "This command returns a list of all topics within the server",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/main.go
+++ b/main.go
@@ -29,10 +29,12 @@ func main() {
 			"  ARREBATO_TLS_KEY         The location of the client private key",
 	}
 
+	command.SetErr(os.Stderr)
 	command.AddCommand(
 		cmd.Server(),
 		cmd.Create(),
 		cmd.List(),
+		cmd.Describe(),
 	)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)

--- a/pkg/arrebato/signing.go
+++ b/pkg/arrebato/signing.go
@@ -13,8 +13,8 @@ import (
 type (
 	// The KeyPair type contains the public and private signing keys for the client to use when producing messages.
 	KeyPair struct {
-		PublicKey  []byte
-		PrivateKey []byte
+		PublicKey  []byte `json:"publicKey"`
+		PrivateKey []byte `json:"privateKey"`
 	}
 )
 

--- a/pkg/arrebato/topic.go
+++ b/pkg/arrebato/topic.go
@@ -17,16 +17,16 @@ type (
 	// The Topic type describes a topic stored within the cluster.
 	Topic struct {
 		// The Name of the Topic.
-		Name string
+		Name string `json:"name"`
 
 		// The amount of time messages on the Topic will be stored.
-		MessageRetentionPeriod time.Duration
+		MessageRetentionPeriod time.Duration `json:"messageRetentionPeriod"`
 
 		// The maximum age of a consumer index on a Topic before it is reset to zero.
-		ConsumerRetentionPeriod time.Duration
+		ConsumerRetentionPeriod time.Duration `json:"consumerRetentionPeriod"`
 
 		// If true, any attempts to publish an unverified message onto this topic will fail.
-		RequireVerifiedMessages bool
+		RequireVerifiedMessages bool `json:"requireVerifiedMessages"`
 	}
 )
 


### PR DESCRIPTION
This commit adds the describe topic command to the CLI to get more details
on a specific topic. JSON output support has also been added to the signing
key creation command.

Signed-off-by: David Bond <davidsbond93@gmail.com>