### PR TITLE
Add helper method for running a command with a client

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/davidsbond/arrebato/pkg/arrebato"
 )
 
@@ -42,4 +44,15 @@ func loadClient(ctx context.Context) (*arrebato.Client, error) {
 	}
 
 	return arrebato.Dial(ctx, config)
+}
+
+func withClient(fn func(ctx context.Context, client *arrebato.Client, args []string) error) func(command *cobra.Command, args []string) error {
+	return func(command *cobra.Command, args []string) error {
+		client, err := loadClient(command.Context())
+		if err != nil {
+			return err
+		}
+
+		return fn(command.Context(), client, args)
+	}
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -41,20 +42,15 @@ func createTopic() *cobra.Command {
 		Args:  cobra.ExactValidArgs(1),
 		Short: "Create a new topic",
 		Long:  "This command creates a new topic with the configuration provided by the CLI",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := loadClient(cmd.Context())
-			if err != nil {
-				return err
-			}
-
+		RunE: withClient(func(ctx context.Context, client *arrebato.Client, args []string) error {
 			name := args[0]
-			return client.CreateTopic(cmd.Context(), arrebato.Topic{
+			return client.CreateTopic(ctx, arrebato.Topic{
 				Name:                    name,
 				MessageRetentionPeriod:  messageRetentionPeriod,
 				ConsumerRetentionPeriod: consumerRetentionPeriod,
 				RequireVerifiedMessages: requireVerifiedMessages,
 			})
-		},
+		}),
 	}
 
 	flags := cmd.PersistentFlags()
@@ -72,13 +68,8 @@ func createSigningKey() *cobra.Command {
 		Use:   "signing-key [flags]",
 		Short: "Create a new signing key pair",
 		Long:  "This command creates a new signing key pair for this client to use when producing messages",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := loadClient(cmd.Context())
-			if err != nil {
-				return err
-			}
-
-			keyPair, err := client.CreateSigningKeyPair(cmd.Context())
+		RunE: withClient(func(ctx context.Context, client *arrebato.Client, args []string) error {
+			keyPair, err := client.CreateSigningKeyPair(ctx)
 			if err != nil {
 				return err
 			}
@@ -91,7 +82,7 @@ func createSigningKey() *cobra.Command {
 			fmt.Printf("Public key:\t%s\n", base64.StdEncoding.EncodeToString(keyPair.PublicKey))
 			fmt.Printf("Private key:\t%s\n", base64.StdEncoding.EncodeToString(keyPair.PrivateKey))
 			return nil
-		},
+		}),
 	}
 
 	flags := cmd.PersistentFlags()

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -1,11 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/davidsbond/arrebato/pkg/arrebato"
 )
 
 // Describe returns a command for describing various server resources.
@@ -31,13 +34,8 @@ func describeTopic() *cobra.Command {
 		Short: "Describe a topics",
 		Long:  "This command returns information about a single topic",
 		Args:  cobra.ExactValidArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := loadClient(cmd.Context())
-			if err != nil {
-				return err
-			}
-
-			topic, err := client.Topic(cmd.Context(), args[0])
+		RunE: withClient(func(ctx context.Context, client *arrebato.Client, args []string) error {
+			topic, err := client.Topic(ctx, args[0])
 			if err != nil {
 				return err
 			}
@@ -52,7 +50,7 @@ func describeTopic() *cobra.Command {
 			fmt.Println("Require Verified Messages:", topic.RequireVerifiedMessages)
 
 			return nil
-		},
+		}),
 	}
 
 	flags := cmd.PersistentFlags()

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,11 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/davidsbond/arrebato/pkg/arrebato"
 )
 
 // List returns a command for listing various server resources.
@@ -30,13 +33,8 @@ func listTopics() *cobra.Command {
 		Use:   "topics [flags]",
 		Short: "List all topics",
 		Long:  "This command returns a list of all topics within the server",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := loadClient(cmd.Context())
-			if err != nil {
-				return err
-			}
-
-			topics, err := client.Topics(cmd.Context())
+		RunE: withClient(func(ctx context.Context, client *arrebato.Client, args []string) error {
+			topics, err := client.Topics(ctx)
 			if err != nil {
 				return err
 			}
@@ -55,7 +53,7 @@ func listTopics() *cobra.Command {
 			}
 
 			return nil
-		},
+		}),
 	}
 
 	flags := cmd.PersistentFlags()


### PR DESCRIPTION
This commit adds a withClient helper function that can be used to run a command that
requires a client for the server.

Signed-off-by: David Bond <davidsbond93@gmail.com>