### PR TITLE
Add workflow for proto file formatting

### DIFF
--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -50,6 +50,45 @@ jobs:
           git add .
           git diff --staged --exit-code
 
+  format:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.18.x'
+
+      - name: Get cache paths
+        id: cache
+        run: |
+          echo "::set-output name=build::$(go env GOCACHE)"
+          echo "::set-output name=module::$(go env GOMODCACHE)"
+
+      - name: Set up cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ steps.cache.outputs.build }}
+            ${{ steps.cache.outputs.module }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Install tools
+        run: |
+          make install-buf
+
+      - name: Format proto files
+        run: make proto-format
+
+      - name: Check for uncommitted changes
+        run: |
+          git add .
+          git diff --staged --exit-code
+
   lint:
     runs-on: ubuntu-20.04
     steps:
@@ -89,6 +128,7 @@ jobs:
     needs:
       - lint
       - generate
+      - format
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ proto-lint:
 proto-breaking:
 	buf breaking --against 'https://github.com/davidsbond/arrebato.git#branch=master'
 
+proto-format:
+	buf format -w
+
 docker-compose: build
 	docker-compose down
 	docker-compose build

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/anchore/syft v0.42.4
 	github.com/armon/go-metrics v0.3.10
-	github.com/bufbuild/buf v1.1.1
+	github.com/bufbuild/buf v1.2.1
 	github.com/golangci/golangci-lint v1.45.2
 	github.com/google/uuid v1.3.0
 	github.com/goreleaser/goreleaser v1.7.0
@@ -286,6 +286,7 @@ require (
 	github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a // indirect
 	github.com/jedisct1/go-minisign v0.0.0-20210703085342-c1f07ee84431 // indirect
 	github.com/jgautheron/goconst v1.5.1 // indirect
+	github.com/jhump/protocompile v0.0.0-20220209020618-b218a88181be // indirect
 	github.com/jhump/protoreflect v1.12.0 // indirect
 	github.com/jingyugao/rowserrcheck v1.1.1 // indirect
 	github.com/jinzhu/copier v0.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -507,8 +507,8 @@ github.com/breml/bidichk v0.2.2/go.mod h1:zbfeitpevDUGI7V91Uzzuwrn4Vls8MoBMrwtt7
 github.com/breml/errchkjson v0.2.3 h1:97eGTmR/w0paL2SwfRPI1jaAZHaH/fXnxWTw2eEIqE0=
 github.com/breml/errchkjson v0.2.3/go.mod h1:jZEATw/jF69cL1iy7//Yih8yp/mXp2CBoBr9GJwCAsY=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
-github.com/bufbuild/buf v1.1.1 h1:jaWJst8qTICzmQiMhbNwxt1Zxbf+wJBGm9+++CfaeZA=
-github.com/bufbuild/buf v1.1.1/go.mod h1:u1jq+nOI99bBz+3K4IvY5mbCg8vAEVTZIt7KnxZ6nC4=
+github.com/bufbuild/buf v1.2.1 h1:rEjRF9noYZHbU4OjVbzUHptm88kZSsnth9D1mHRk5ic=
+github.com/bufbuild/buf v1.2.1/go.mod h1:2+YDhYsLYzHnEZvigKafao+dY58ZHp830hC9T5NVZY0=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
@@ -1582,6 +1582,8 @@ github.com/jgautheron/goconst v1.5.1/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7H
 github.com/jhump/gopoet v0.0.0-20190322174617-17282ff210b3/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
 github.com/jhump/gopoet v0.1.0/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
 github.com/jhump/goprotoc v0.5.0/go.mod h1:VrbvcYrQOrTi3i0Vf+m+oqQWk9l72mjkJCYo7UvLHRQ=
+github.com/jhump/protocompile v0.0.0-20220209020618-b218a88181be h1:KaWUOInov+KmpTsneglPtk85TNdircm5dkewhuMW4iA=
+github.com/jhump/protocompile v0.0.0-20220209020618-b218a88181be/go.mod h1:qr2b5kx4HbFS7/g4uYO5qv9ei8303JMsC7ESbYiqr2Q=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/jhump/protoreflect v1.6.1/go.mod h1:RZQ/lnuN+zqeRVpQigTwO6o0AJUkxbnSnpuG7toUTG4=
 github.com/jhump/protoreflect v1.8.2/go.mod h1:7GcYQDdMU/O/BBrl/cX6PNHpXh6cenjd8pneu5yW7Tg=
@@ -3394,6 +3396,7 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.25.1-0.20200805231151-a709e31e5d12/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=

--- a/proto/arrebato/acl/command/v1/command.proto
+++ b/proto/arrebato/acl/command/v1/command.proto
@@ -1,12 +1,12 @@
 syntax = "proto3";
 
-option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/acl/command/v1;aclcmd";
-
-import "arrebato/acl/v1/acl.proto";
-
 // Package arrebato.acl.command.v1 provides commands written to the raft log regarding acl state.
 // These messages are used internally by nodes in the cluster to portray changes from the leader node to all followers.
 package arrebato.acl.command.v1;
+
+import "arrebato/acl/v1/acl.proto";
+
+option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/acl/command/v1;aclcmd";
 
 // The SetACL message is a command indicating that the server's ACL has changed.
 message SetACL {

--- a/proto/arrebato/acl/service/v1/service.proto
+++ b/proto/arrebato/acl/service/v1/service.proto
@@ -1,12 +1,12 @@
 syntax = "proto3";
 
-option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/acl/service/v1;aclsvc";
-
-import "arrebato/acl/v1/acl.proto";
-
 // Package arrebato.acl.service.v1 provides the schema for the ACLService, which is used to manage acls within the
 // cluster.
 package arrebato.acl.service.v1;
+
+import "arrebato/acl/v1/acl.proto";
+
+option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/acl/service/v1;aclsvc";
 
 // The ACLService is a gRPC service that can manage acls within the cluster.
 service ACLService {
@@ -23,14 +23,10 @@ message SetRequest {
 }
 
 // The SetResponse message is the response DTO when calling ACLService.Set.
-message SetResponse {
-
-}
+message SetResponse {}
 
 // The GetRequest message is the request DTO when calling ACLService.Get.
-message GetRequest {
-
-}
+message GetRequest {}
 
 // The GetResponse message is the response DTO when calling ACLService.Get. It contains the acl details.
 message GetResponse {

--- a/proto/arrebato/acl/v1/acl.proto
+++ b/proto/arrebato/acl/v1/acl.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
 
-option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/acl/v1;acl";
-
 // Package arrebato.acl.v1 provides messages that describe access-control lists (ACLs) for clients wishing to consume
 // and produce messages on individual topics.
 package arrebato.acl.v1;
+
+option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/acl/v1;acl";
 
 // The ACL message describes the entire state of the access-control list.
 message ACL {

--- a/proto/arrebato/consumer/command/v1/command.proto
+++ b/proto/arrebato/consumer/command/v1/command.proto
@@ -1,12 +1,12 @@
 syntax = "proto3";
 
-option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/consumer/command/v1;consumercmd";
-
-import "arrebato/consumer/v1/consumer.proto";
-
 // Package arrebato.consumer.command.v1 provides commands written to the raft log regarding consumer states.
 // These messages are used internally by nodes in the cluster to portray changes from the leader node to all followers.
 package arrebato.consumer.command.v1;
+
+import "arrebato/consumer/v1/consumer.proto";
+
+option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/consumer/command/v1;consumercmd";
 
 // The SetTopicIndex message is a command indicating that a consumer's index within a topic has changed.
 message SetTopicIndex {

--- a/proto/arrebato/consumer/service/v1/service.proto
+++ b/proto/arrebato/consumer/service/v1/service.proto
@@ -1,12 +1,12 @@
 syntax = "proto3";
 
-option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/consumer/service/v1;consumersvc";
-
-import "arrebato/consumer/v1/consumer.proto";
-
 // Package arrebato.consumer.service.v1 provides the schema for the ConsumerService, which is used to manage the state
 // of topic consumers.
 package arrebato.consumer.service.v1;
+
+import "arrebato/consumer/v1/consumer.proto";
+
+option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/consumer/service/v1;consumersvc";
 
 // The ConsumerService is a gRPC service that can manage the state of topic consumers.
 service ConsumerService {
@@ -22,6 +22,4 @@ message SetTopicIndexRequest {
 }
 
 // The SetTopicIndexResponse message is the response DTO when calling ConsumerService.SetTopicIndex.
-message SetTopicIndexResponse {
-
-}
+message SetTopicIndexResponse {}

--- a/proto/arrebato/consumer/v1/consumer.proto
+++ b/proto/arrebato/consumer/v1/consumer.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
 
-option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/consumer/v1;consumer";
+package arrebato.consumer.v1;
 
 import "google/protobuf/timestamp.proto";
 
-package arrebato.consumer.v1;
+option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/consumer/v1;consumer";
 
 message TopicIndex {
   string topic = 1;

--- a/proto/arrebato/message/command/v1/command.proto
+++ b/proto/arrebato/message/command/v1/command.proto
@@ -1,12 +1,12 @@
 syntax = "proto3";
 
-option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/message/command/v1;messagecmd";
-
-import "arrebato/message/v1/message.proto";
-
 // Package arrebato.message.command.v1 provides commands written to the raft log regarding produced/consumed messages.
 // These messages are used internally by nodes in the cluster to portray changes from the leader node to all followers.
 package arrebato.message.command.v1;
+
+import "arrebato/message/v1/message.proto";
+
+option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/message/command/v1;messagecmd";
 
 // The CreateMessage message is a command indicating that a new message has been produced.
 message CreateMessage {

--- a/proto/arrebato/message/service/v1/service.proto
+++ b/proto/arrebato/message/service/v1/service.proto
@@ -1,12 +1,12 @@
 syntax = "proto3";
 
-option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/message/service/v1;messagesvc";
-
-import "arrebato/message/v1/message.proto";
-
 // Package arrebato.message.service.v1 provides the schema for the MessageService, which is used to consume and produce
 // messages.
 package arrebato.message.service.v1;
+
+import "arrebato/message/v1/message.proto";
+
+option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/message/service/v1;messagesvc";
 
 // The MessageService is a gRPC service that can manage read and write messages to the cluster.
 service MessageService {
@@ -24,9 +24,7 @@ message ProduceRequest {
 }
 
 // The ProduceResponse message is the response DTO when calling MessageService.Produce.
-message ProduceResponse {
-
-}
+message ProduceResponse {}
 
 // The ConsumeRequest message is the request DTO when calling MessageService.Consume. It describes the topic to consume
 // from and the name of the consumer.

--- a/proto/arrebato/message/v1/message.proto
+++ b/proto/arrebato/message/v1/message.proto
@@ -1,12 +1,12 @@
 syntax = "proto3";
 
-option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/message/v1;message";
+// Package arrebato.message.v1 provides domain models for messages.
+package arrebato.message.v1;
 
 import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 
-// Package arrebato.message.v1 provides domain models for messages.
-package arrebato.message.v1;
+option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/message/v1;message";
 
 // The Message message describes a single message stored within a topic.
 message Message {

--- a/proto/arrebato/node/service/v1/service.proto
+++ b/proto/arrebato/node/service/v1/service.proto
@@ -1,12 +1,12 @@
 syntax = "proto3";
 
-option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/node/service/v1;nodesvc";
-
-import "arrebato/node/v1/node.proto";
-
 // Package arrebato.node.service.v1 provides the schema for the NodeService, which is used to describe nodes within the
 // cluster.
 package arrebato.node.service.v1;
+
+import "arrebato/node/v1/node.proto";
+
+option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/node/service/v1;nodesvc";
 
 // The NodeService is a gRPC service that can introspects node information.
 service NodeService {
@@ -15,9 +15,7 @@ service NodeService {
 }
 
 // The DescribeRequest message is the request DTO when calling NodeService.Describe.
-message DescribeRequest {
-
-}
+message DescribeRequest {}
 
 // The DescribeResponse message is the response DTO when calling NodeService.Describe. It contains node details.
 message DescribeResponse {

--- a/proto/arrebato/node/v1/node.proto
+++ b/proto/arrebato/node/v1/node.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
 
-option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/node/v1;node";
-
 // Package arrebato.node.v1 provides domain models for nodes.
 package arrebato.node.v1;
+
+option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/node/v1;node";
 
 // The Node message describes a single node within the cluster.
 message Node {

--- a/proto/arrebato/signing/command/v1/command.proto
+++ b/proto/arrebato/signing/command/v1/command.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
 
-option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/signing/command/v1;signingcmd";
-
 // Package arrebato.signing.command.v1 provides commands written to the raft log regarding signing key management. These
 // messages are used internally by nodes in the cluster to portray changes from the leader node to all followers.
 package arrebato.signing.command.v1;
+
+option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/signing/command/v1;signingcmd";
 
 // The CreatePublicKey message is a command indicating that a new signing key has been created.
 message CreatePublicKey {
@@ -13,4 +13,3 @@ message CreatePublicKey {
   // The public key for verifying signed messages.
   bytes public_key = 2;
 }
-

--- a/proto/arrebato/signing/service/v1/service.proto
+++ b/proto/arrebato/signing/service/v1/service.proto
@@ -1,12 +1,12 @@
 syntax = "proto3";
 
-option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/signing/service/v1;signingsvc";
-
-import "arrebato/signing/v1/signing.proto";
-
 // Package arrebato.signing.service.v1 provides the schema for the SigningService, which is used to manage signing keys within the
 // cluster.
 package arrebato.signing.service.v1;
+
+import "arrebato/signing/v1/signing.proto";
+
+option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/signing/service/v1;signingsvc";
 
 // The SigningService is a gRPC service that can manage signing keys within the cluster.
 service SigningService {

--- a/proto/arrebato/signing/v1/signing.proto
+++ b/proto/arrebato/signing/v1/signing.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
 
-option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/signing/v1;signing";
-
 // Package arrebato.signing.v1 provides domain models for signing keys.
 package arrebato.signing.v1;
+
+option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/signing/v1;signing";
 
 // The KeyPair message describes a single public/private key pair used for message signing.
 message KeyPair {

--- a/proto/arrebato/topic/command/v1/command.proto
+++ b/proto/arrebato/topic/command/v1/command.proto
@@ -1,12 +1,12 @@
 syntax = "proto3";
 
-option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/topic/command/v1;topiccmd";
-
-import "arrebato/topic/v1/topic.proto";
-
 // Package arrebato.topic.command.v1 provides commands written to the raft log regarding topic management. These messages
 // are used internally by nodes in the cluster to portray changes from the leader node to all followers.
 package arrebato.topic.command.v1;
+
+import "arrebato/topic/v1/topic.proto";
+
+option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/topic/command/v1;topiccmd";
 
 // The CreateTopic message is a command indicating that a new topic has been created.
 message CreateTopic {

--- a/proto/arrebato/topic/service/v1/service.proto
+++ b/proto/arrebato/topic/service/v1/service.proto
@@ -1,12 +1,12 @@
 syntax = "proto3";
 
-option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/topic/service/v1;topicsvc";
-
-import "arrebato/topic/v1/topic.proto";
-
 // Package arrebato.topic.service.v1 provides the schema for the TopicService, which is used to manage topics within the
 // cluster.
 package arrebato.topic.service.v1;
+
+import "arrebato/topic/v1/topic.proto";
+
+option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/topic/service/v1;topicsvc";
 
 // The TopicService is a gRPC service that can manage topics within the cluster.
 service TopicService {
@@ -28,9 +28,7 @@ message CreateRequest {
 }
 
 // The CreateResponse message is the response DTO when calling TopicService.Create.
-message CreateResponse {
-
-}
+message CreateResponse {}
 
 // The DeleteRequest message is the request DTO when calling TopicService.Delete. It describes the topic to be deleted.
 message DeleteRequest {
@@ -39,9 +37,7 @@ message DeleteRequest {
 }
 
 // The DeleteResponse message is the response DTO when calling TopicService.Delete.
-message DeleteResponse {
-
-}
+message DeleteResponse {}
 
 // The GetRequest message is the request DTO when calling TopicService.Get. It describes the topic to get more information
 // about.
@@ -57,9 +53,7 @@ message GetResponse {
   arrebato.topic.v1.Topic topic = 1;
 }
 
-message ListRequest {
-
-}
+message ListRequest {}
 
 message ListResponse {
   repeated arrebato.topic.v1.Topic topics = 1;

--- a/proto/arrebato/topic/v1/topic.proto
+++ b/proto/arrebato/topic/v1/topic.proto
@@ -1,11 +1,11 @@
 syntax = "proto3";
 
-option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/topic/v1;topic";
+// Package arrebato.topic.v1 provides domain models for topics.
+package arrebato.topic.v1;
 
 import "google/protobuf/duration.proto";
 
-// Package arrebato.topic.v1 provides domain models for topics.
-package arrebato.topic.v1;
+option go_package = "github.com/davidsbond/arrebato/internal/proto/arrebato/topic/v1;topic";
 
 // The Topic message describes a single topic within the cluster.
 message Topic {


### PR DESCRIPTION
This commit adds a new workflow that ensures proto files are correctly
formatted. This has been introuced as the buf tool now has a format
command.

Signed-off-by: David Bond <davidsbond93@gmail.com>