### PR TITLE
Use advertise address as raft local ID

### DIFF
--- a/deploy/kustomize/statefulset.yaml
+++ b/deploy/kustomize/statefulset.yaml
@@ -37,7 +37,7 @@ spec:
                 labelSelector:
                   matchLabels:
                     app: arrebato
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 120
       containers:
         - name: server
           image: ghcr.io/davidsbond/arrebato:latest
@@ -71,7 +71,7 @@ spec:
             - server
             - --peers=arrebato-0.arrebato.$(NAMESPACE).svc.cluster.local
             - --advertise-address=$(POD_NAME).arrebato.$(NAMESPACE).svc.cluster.local
-            - --log-level=5
+            - --log-level=2
           volumeMounts:
             - mountPath: /var/lib/arrebato
               name: data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,21 +3,25 @@ services:
   arrebato-0:
     build:
       context: .
+    stop_grace_period: "60s"
     restart: on-failure
     command:
       - server
       - --log-level=2
+      - --advertise-address=arrebato-0
     networks:
       - default
 
   arrebato-1:
     build:
       context: .
+    stop_grace_period: "60s"
     restart: on-failure
     command:
       - server
       - --peers=arrebato-0
       - --log-level=2
+      - --advertise-address=arrebato-1
     depends_on:
       - arrebato-0
     networks:
@@ -26,13 +30,15 @@ services:
   arrebato-2:
     build:
       context: .
+    stop_grace_period: "60s"
     restart: on-failure
     command:
       - server
       - --peers=arrebato-0
       - --log-level=2
+      - --advertise-address=arrebato-2
     depends_on:
-      - arrebato-0
+      - arrebato-1
     networks:
       - default
 

--- a/internal/server/serf.go
+++ b/internal/server/serf.go
@@ -118,6 +118,7 @@ func (svr *Server) handleSerfEventMemberLeave(ctx context.Context, event serf.Me
 			return ctx.Err()
 		}
 
+		svr.logger.Info("removing server", "name", member.Name)
 		if err := svr.raft.RemoveServer(raft.ServerID(member.Name), 0, svr.config.Raft.Timeout).Error(); err != nil {
 			return fmt.Errorf("failed to remove voter %s: %w", member.Name, err)
 		}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/spf13/cobra"
 
@@ -37,7 +38,7 @@ func main() {
 		cmd.Describe(),
 	)
 
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	if err := command.ExecuteContext(ctx); err != nil {
 		cancel()
 		os.Exit(1)


### PR DESCRIPTION
This commit modifies the raft bootstrapping process to use the node's
advertise address as the raft local id. This is required as the
initial implementation in a kubernetes cluster causes the following
response when requesting peers:

```
peers = ["0.0.0.0:5000", "arrebato-1.arrebato.svc.cluster.local, ...]
```

The first element in the array should also be the k8s service address, which
is taken from the advertise address.

Signed-off-by: David Bond <davidsbond93@gmail.com>