### PR TITLE
Ensure all topics are allocated on leadership transfer

### DIFF
--- a/internal/node/store_test.go
+++ b/internal/node/store_test.go
@@ -112,3 +112,25 @@ func TestBoltStore_AllocateTopic(t *testing.T) {
 		require.NoError(t, store.AllocateTopic(ctx, "node-0", "topic-0"))
 	})
 }
+
+func TestBoltStore_List(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t)
+	db := testutil.BoltDB(t)
+
+	store := node.NewBoltStore(db)
+
+	// Add a node to the state
+	require.NoError(t, store.Add(ctx, &nodepb.Node{
+		Name: "node-0",
+	}))
+
+	t.Run("It should return all nodes", func(t *testing.T) {
+		actual, err := store.List(ctx)
+		require.NoError(t, err)
+		if assert.Len(t, actual, 1) {
+			assert.EqualValues(t, "node-0", actual[0].GetName())
+		}
+	})
+}


### PR DESCRIPTION
This commit modifies the server code to ensure all topics in the state are
allocated to a node when leadership transfers occur. This should catch any
timing issues where a topic is created, leadership transfer occurs and
then the topic cannot be allocated by the same node.

Signed-off-by: David Bond <davidsbond93@gmail.com>