### PR TITLE
Store messages in their own partitions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -37,6 +37,7 @@ linters:
     - contextcheck
     - containedctx
     - nilerr
+    - gocognit
 
 issues:
   exclude-use-default: false

--- a/e2e/message_test.go
+++ b/e2e/message_test.go
@@ -31,7 +31,7 @@ func (s *MessageSuite) TestProduceConsumeMessages() {
 		Name:                    "test-suite-topic",
 		MessageRetentionPeriod:  time.Hour,
 		ConsumerRetentionPeriod: time.Hour,
-		Partitions:              100,
+		Partitions:              1,
 	}))
 
 	expected := structpb.NewStringValue("hello-world")

--- a/internal/message/grpc.go
+++ b/internal/message/grpc.go
@@ -54,7 +54,7 @@ type (
 	Reader interface {
 		// Read should start reading messages within a topic starting from a given index, invoking the ReadFunc for
 		// each message.
-		Read(ctx context.Context, topic string, startIndex uint64, fn ReadFunc) error
+		Read(ctx context.Context, topic string, partition uint32, startIndex uint64, fn ReadFunc) error
 	}
 
 	// The TopicIndexGetter interface describes types that can retrieve the current index on a topic for a consumer.
@@ -234,7 +234,7 @@ func (svr *GRPC) Consume(request *messagesvc.ConsumeRequest, server messagesvc.M
 			// of all available messages we wait via the ticker and check again for new messages from the last known
 			// index. This allows the client to stay connected and keep getting more messages, without over-polling
 			// the data store.
-			err := svr.reader.Read(ctx, request.GetTopic(), topicIndex.GetIndex(), func(ctx context.Context, m *message.Message) error {
+			err := svr.reader.Read(ctx, request.GetTopic(), 0, topicIndex.GetIndex(), func(ctx context.Context, m *message.Message) error {
 				resp := &messagesvc.ConsumeResponse{Message: m}
 
 				if err = server.Send(resp); err != nil {

--- a/internal/message/mocks_test.go
+++ b/internal/message/mocks_test.go
@@ -72,7 +72,7 @@ func (mm *MockTopicIndexGetter) GetTopicIndex(ctx context.Context, topic string,
 	}, nil
 }
 
-func (mm *MockReader) Read(ctx context.Context, topic string, startIndex uint64, fn message.ReadFunc) error {
+func (mm *MockReader) Read(ctx context.Context, topic string, partition uint32, startIndex uint64, fn message.ReadFunc) error {
 	if mm.err != nil {
 		return mm.err
 	}

--- a/internal/message/partition.go
+++ b/internal/message/partition.go
@@ -28,6 +28,11 @@ func NewCRC32Partitioner() *CRC32Partitioner {
 // Partition returns a uint32 value denoting the expected partition of the provided proto.Message implementation. The
 // message is deterministically marshalled and passed into the crc32 hashing function.
 func (p *CRC32Partitioner) Partition(m proto.Message, max uint32) (uint32, error) {
+	// Shortcut for topics that only have a single partition.
+	if max == 1 {
+		return 0, nil
+	}
+
 	// In order to ensure that we always choose the same partition for the same key/message content, we need to do
 	// proto encoding deterministically, as a small difference in the binary representation can change the checksum
 	// and then the designated partition.

--- a/internal/prune/prune_test.go
+++ b/internal/prune/prune_test.go
@@ -35,6 +35,7 @@ func TestPruner_PruneMessages(t *testing.T) {
 	require.NoError(t, topics.Create(ctx, &topicpb.Topic{
 		Name:                   "test-topic",
 		MessageRetentionPeriod: durationpb.New(time.Second),
+		Partitions:             1,
 	}))
 
 	messages := message.NewBoltStore(db)
@@ -69,7 +70,7 @@ func TestPruner_PruneMessages(t *testing.T) {
 	// be the second one we produced with the string "world" as the payload.
 	assert.Eventually(t, func() bool {
 		var gotMessage bool
-		_ = messages.Read(ctx, "test-topic", 0, func(ctx context.Context, m *messagepb.Message) error {
+		_ = messages.Read(ctx, "test-topic", 0, 0, func(ctx context.Context, m *messagepb.Message) error {
 			payload, err := m.GetValue().UnmarshalNew()
 			require.NoError(t, err)
 

--- a/internal/topic/store_test.go
+++ b/internal/topic/store_test.go
@@ -27,6 +27,7 @@ func TestBoltStore_Create(t *testing.T) {
 		assert.NoError(t, topics.Create(ctx, &topicpb.Topic{
 			Name:                   topicName,
 			MessageRetentionPeriod: durationpb.New(retentionPeriod),
+			Partitions:             10,
 		}))
 	})
 
@@ -34,6 +35,7 @@ func TestBoltStore_Create(t *testing.T) {
 		err := topics.Create(ctx, &topicpb.Topic{
 			Name:                   topicName,
 			MessageRetentionPeriod: durationpb.New(retentionPeriod),
+			Partitions:             10,
 		})
 
 		assert.EqualValues(t, topic.ErrTopicExists, err)


### PR DESCRIPTION
This commit modifies the message storage layer to store messages in child-buckets named
after the partition they are assigned to. These messages will have ordinal indexes within
those partitions.

e2e tests have been updated to just use a single partition while consumer grouping can be
implemented. When topics are created, the child buckets for the number of partitions will
also be created. The existing message consumption code will also always use partition zero
to start with.

Signed-off-by: David Bond <davidsbond93@gmail.com>