### PR TITLE
Restrict consumers to the node the topic is allocated to

### DIFF
--- a/internal/message/mocks_test.go
+++ b/internal/message/mocks_test.go
@@ -50,7 +50,15 @@ type (
 	MockTopicGetter struct {
 		topic *topicpb.Topic
 	}
+
+	MockNodeStore struct {
+		allocated bool
+	}
 )
+
+func (mm *MockNodeStore) IsAllocatedToNode(ctx context.Context, name, topic string) (bool, error) {
+	return mm.allocated, nil
+}
 
 func (mm *MockTopicGetter) Get(ctx context.Context, name string) (*topicpb.Topic, error) {
 	return mm.topic, nil

--- a/internal/node/grpc.go
+++ b/internal/node/grpc.go
@@ -3,6 +3,7 @@ package node
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/raft"
 	"google.golang.org/grpc"
@@ -19,8 +20,9 @@ type (
 	// The GRPC type is a nodesvc.NodeServiceServer implementation that handles inbound gRPC requests to get
 	// information on the node.
 	GRPC struct {
-		raft    Raft
-		localID raft.ServerID
+		raft   Raft
+		nodeID string
+		nodes  Getter
 	}
 
 	// The Raft interface describes types that can return information regarding the raft state.
@@ -28,11 +30,15 @@ type (
 		State() raft.RaftState
 		GetConfiguration() raft.ConfigurationFuture
 	}
+
+	Getter interface {
+		Get(ctx context.Context, name string) (*node.Node, error)
+	}
 )
 
 // NewGRPC returns a new instance of the GRPC type that returns node information based on the Raft state.
-func NewGRPC(raft Raft, localID raft.ServerID) *GRPC {
-	return &GRPC{raft: raft, localID: localID}
+func NewGRPC(raft Raft, nodeID string, getter Getter) *GRPC {
+	return &GRPC{raft: raft, nodeID: nodeID, nodes: getter}
 }
 
 // Register the GRPC service onto the grpc.ServiceRegistrar.
@@ -42,7 +48,15 @@ func (svr *GRPC) Register(registrar grpc.ServiceRegistrar, health *health.Server
 }
 
 // Describe the node.
-func (svr *GRPC) Describe(_ context.Context, _ *nodesvc.DescribeRequest) (*nodesvc.DescribeResponse, error) {
+func (svr *GRPC) Describe(ctx context.Context, _ *nodesvc.DescribeRequest) (*nodesvc.DescribeResponse, error) {
+	record, err := svr.nodes.Get(ctx, svr.nodeID)
+	switch {
+	case errors.Is(err, ErrNoNode):
+		return nil, status.Error(codes.NotFound, "failed to find node record")
+	case err != nil:
+		return nil, status.Errorf(codes.Internal, "failed to query node: %v", err)
+	}
+
 	future := svr.raft.GetConfiguration()
 	if future.Error() != nil {
 		return nil, status.Errorf(codes.Internal, "failed to query raft configuration: %v", future.Error())
@@ -51,18 +65,17 @@ func (svr *GRPC) Describe(_ context.Context, _ *nodesvc.DescribeRequest) (*nodes
 	config := future.Configuration()
 	peers := make([]string, 0)
 	for _, server := range config.Servers {
-		if server.ID == svr.localID {
+		if server.ID == raft.ServerID(svr.nodeID) {
 			continue
 		}
 
 		peers = append(peers, string(server.ID))
 	}
 
+	record.Peers = peers
+	record.Leader = svr.raft.State() == raft.Leader
+
 	return &nodesvc.DescribeResponse{
-		Node: &node.Node{
-			Name:   string(svr.localID),
-			Leader: svr.raft.State() == raft.Leader,
-			Peers:  peers,
-		},
+		Node: record,
 	}, nil
 }

--- a/internal/node/grpc_test.go
+++ b/internal/node/grpc_test.go
@@ -49,8 +49,7 @@ func TestGRPC_Describe(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			ctx := testutil.Context(t)
 			r := &MockRaft{state: tc.State, config: tc.Config}
-			localID := raft.ServerID("test-server")
-			actual, err := node.NewGRPC(r, localID).Describe(ctx, &nodesvc.DescribeRequest{})
+			actual, err := node.NewGRPC(r, "test-server", nil).Describe(ctx, &nodesvc.DescribeRequest{})
 			assert.NoError(t, err)
 			assert.True(t, proto.Equal(tc.Expected, actual))
 		})

--- a/internal/node/handler_test.go
+++ b/internal/node/handler_test.go
@@ -55,7 +55,7 @@ func TestHandler_Add(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
 			ctx := testutil.Context(t)
-			store := &MockStore{err: tc.Error}
+			store := &MockModifier{err: tc.Error}
 
 			err := node.NewHandler(store, hclog.NewNullLogger()).Add(ctx, tc.Command)
 			if tc.ExpectsError {
@@ -104,7 +104,7 @@ func TestHandler_Remove(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
 			ctx := testutil.Context(t)
-			store := &MockStore{err: tc.Error}
+			store := &MockModifier{err: tc.Error}
 
 			err := node.NewHandler(store, hclog.NewNullLogger()).Remove(ctx, tc.Command)
 			if tc.ExpectsError {
@@ -147,7 +147,7 @@ func TestHandler_AllocateTopic(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
 			ctx := testutil.Context(t)
-			store := &MockStore{err: tc.Error}
+			store := &MockModifier{err: tc.Error}
 
 			err := node.NewHandler(store, hclog.NewNullLogger()).AllocateTopic(ctx, tc.Command)
 			if tc.ExpectsError {

--- a/internal/node/mocks_test.go
+++ b/internal/node/mocks_test.go
@@ -20,22 +20,22 @@ type (
 		config raft.Configuration
 	}
 
-	MockStore struct {
+	MockModifier struct {
 		added *node.Node
 		err   error
 	}
 )
 
-func (mm *MockStore) AllocateTopic(ctx context.Context, name string, topic string) error {
+func (mm *MockModifier) AllocateTopic(ctx context.Context, name string, topic string) error {
 	return mm.err
 }
 
-func (mm *MockStore) Add(ctx context.Context, node *node.Node) error {
+func (mm *MockModifier) Add(ctx context.Context, node *node.Node) error {
 	mm.added = node
 	return mm.err
 }
 
-func (mm *MockStore) Remove(ctx context.Context, name string) error {
+func (mm *MockModifier) Remove(ctx context.Context, name string) error {
 	return mm.err
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -157,7 +157,7 @@ func New(config Config) (*Server, error) {
 	// Node stack
 	server.nodeStore = node.NewBoltStore(server.store)
 	server.nodeHandler = node.NewHandler(server.nodeStore, server.logger)
-	server.nodeGRPC = node.NewGRPC(server.raft, raft.ServerID(config.AdvertiseAddress))
+	server.nodeGRPC = node.NewGRPC(server.raft, config.AdvertiseAddress, server.nodeStore)
 
 	// ACL stack
 	server.aclStore = acl.NewBoltStore(server.store)
@@ -190,6 +190,8 @@ func New(config Config) (*Server, error) {
 		server.signingStore,
 		server.topicStore,
 		partitioner,
+		config.AdvertiseAddress,
+		server.nodeStore,
 	)
 
 	// Pruning stack


### PR DESCRIPTION
This commit modifies the message service to reject consumption requests for topics
that are not allocated to the node being queried. It also updates the node
service to include the allocated topics in the response.

Signed-off-by: David Bond <davidsbond93@gmail.com>