### PR TITLE
Allow nodes to join cluster as non-voters

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -49,6 +49,7 @@ func Server() *cobra.Command {
 	flags.DurationVar(&config.Raft.Timeout, "raft-timeout", time.Minute, "The timeout to use for raft transport")
 	flags.IntVar(&config.Raft.MaxSnapshots, "raft-max-snapshots", 3, "The maximum number of raft snapshots to store")
 	flags.IntVar(&config.Raft.MaxPool, "raft-max-pool", 3, "The maximum number of connections in the raft connection pool")
+	flags.BoolVar(&config.Raft.NonVoter, "raft-non-voter", false, "If true, this server will never obtain leadership and will be a read-only replica")
 
 	// Serf configuration
 	flags.IntVar(&config.Serf.Port, "serf-port", 5001, "The port to use for serf transport")

--- a/internal/server/raft.go
+++ b/internal/server/raft.go
@@ -40,6 +40,10 @@ type (
 
 		// MaxSnapshots is the maximum number of raft snapshots to keep.
 		MaxSnapshots int
+
+		// NonVoter determines if the server is added to the cluster as a replica that can
+		// never gain leadership.
+		NonVoter bool
 	}
 )
 
@@ -105,10 +109,15 @@ func setupRaft(config Config, fsm raft.FSM, logger hclog.Logger) (*raft.Raft, *r
 		return nil, nil, err
 	}
 
+	suffrage := raft.Voter
+	if config.Raft.NonVoter {
+		suffrage = raft.Nonvoter
+	}
+
 	bootstrap := raft.Configuration{
 		Servers: []raft.Server{
 			{
-				Suffrage: raft.Voter,
+				Suffrage: suffrage,
 				ID:       raftConfig.LocalID,
 				Address:  raft.ServerAddress(raftAddress),
 			},

--- a/internal/server/serf.go
+++ b/internal/server/serf.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"path/filepath"
+	"strconv"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/memberlist"
@@ -18,6 +20,14 @@ type (
 		// The Port to use for serf transport.
 		Port int
 	}
+)
+
+const (
+	voterKey            = "voter"
+	raftPorKey          = "raft_port"
+	grpcPortKey         = "grpc_port"
+	roleKey             = "role"
+	advertiseAddressKey = "advertise_address"
 )
 
 func setupSerf(config Config, logger hclog.Logger) (<-chan serf.Event, *serf.Serf, error) {
@@ -40,6 +50,13 @@ func setupSerf(config Config, logger hclog.Logger) (<-chan serf.Event, *serf.Ser
 	serfConfig.NodeName = config.AdvertiseAddress
 	serfConfig.SnapshotPath = filepath.Join(config.DataPath, "serf.db")
 	serfConfig.RejoinAfterLeave = true
+	serfConfig.Tags = map[string]string{
+		voterKey:            strconv.FormatBool(!config.Raft.NonVoter),
+		raftPorKey:          strconv.Itoa(config.Raft.Port),
+		grpcPortKey:         strconv.Itoa(config.GRPC.Port),
+		advertiseAddressKey: config.AdvertiseAddress,
+		roleKey:             "server",
+	}
 
 	s, err := serf.Create(serfConfig)
 	if err != nil {
@@ -107,6 +124,10 @@ func (svr *Server) handleSerfEventMemberJoin(ctx context.Context, event serf.Mem
 			return ctx.Err()
 		}
 
+		if !isServer(member.Tags) {
+			continue
+		}
+
 		future := svr.raft.GetConfiguration()
 		if future.Error() != nil {
 			return fmt.Errorf("failed to get raft configuration: %w", future.Error())
@@ -127,8 +148,16 @@ func (svr *Server) handleSerfEventMemberJoin(ctx context.Context, event serf.Mem
 			}
 		}
 
-		peer := fmt.Sprint(member.Name, ":", svr.config.Raft.Port)
-		err := svr.raft.AddVoter(serverID, raft.ServerAddress(peer), 0, svr.config.Raft.Timeout).Error()
+		var err error
+		voter := isVoter(member.Tags)
+		peer := net.JoinHostPort(member.Tags[advertiseAddressKey], member.Tags[raftPorKey])
+
+		if voter {
+			err = svr.raft.AddVoter(serverID, raft.ServerAddress(peer), 0, svr.config.Raft.Timeout).Error()
+		} else {
+			err = svr.raft.AddNonvoter(serverID, raft.ServerAddress(peer), 0, svr.config.Raft.Timeout).Error()
+		}
+
 		switch {
 		case errors.Is(err, raft.ErrLeadershipLost):
 			return nil
@@ -150,6 +179,10 @@ func (svr *Server) handleSerfEventMemberLeave(ctx context.Context, event serf.Me
 			return ctx.Err()
 		}
 
+		if !isServer(member.Tags) {
+			continue
+		}
+
 		svr.logger.Info("removing server", "name", member.Name)
 		err := svr.raft.RemoveServer(raft.ServerID(member.Name), 0, svr.config.Raft.Timeout).Error()
 		switch {
@@ -161,4 +194,12 @@ func (svr *Server) handleSerfEventMemberLeave(ctx context.Context, event serf.Me
 	}
 
 	return nil
+}
+
+func isVoter(m map[string]string) bool {
+	return m[voterKey] == "true"
+}
+
+func isServer(m map[string]string) bool {
+	return m[roleKey] == "server"
 }


### PR DESCRIPTION
This commit modifies the raft/serf configuration to allow servers to join the
cluster as non-voters. This essentially makes them never able to become a leader
and therefore always be a read-only replica.

Server's raft port, advertise address and role are also now included in their
serf tags. This should allow the server to filter out any clients that join
the gossip protocol without advertising themselves as a server.

Signed-off-by: David Bond <davidsbond93@gmail.com>