### PR TITLE
Add configuration for serf-level encryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 *.pem
 *.srl
 *.upx
+serf.key

--- a/Makefile
+++ b/Makefile
@@ -82,5 +82,9 @@ generate-certs:
 	openssl x509 -req -in client-req.pem -days 60 -CA ca-cert.pem -CAkey ca-key.pem -CAcreateserial -out client-cert.pem -extfile hack/v3.ext
 	rm *-req.pem
 
+generate-serf-key:
+	rm -rf serf.key
+	hexdump -n 16 -e '4/4 "%08X" 1 "\n"' /dev/urandom > serf.key
+
 kubeval: kustomize
 	kubeval install.yaml

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -53,6 +53,7 @@ func Server() *cobra.Command {
 
 	// Serf configuration
 	flags.IntVar(&config.Serf.Port, "serf-port", 5001, "The port to use for serf transport")
+	flags.StringVar(&config.Serf.EncryptionKeyFile, "serf-encryption-key", "", "The path to the encryption key file used for serf transport")
 
 	// gRPC configuration
 	flags.IntVar(&config.GRPC.Port, "grpc-port", 5002, "The port to use for gRPC transport")

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -74,6 +74,8 @@ func (svr *Server) serveGRPC(ctx context.Context) error {
 
 		options = append(options, grpc.Creds(credentials.NewTLS(config)))
 		infoExtractor = clientinfo.TLSExtractor
+	} else {
+		svr.logger.Warn("no TLS credentials were provided, gRPC transport will be insecure")
 	}
 
 	options = append(options,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -74,9 +74,6 @@ type (
 
 	// The Config type contains configuration values for the Server.
 	Config struct {
-		// Version of the server.
-		Version string
-
 		// LogLevel denotes the verbosity of logs.
 		LogLevel int
 
@@ -191,6 +188,7 @@ func New(config Config) (*Server, error) {
 }
 
 func setupStore(config Config, logger hclog.Logger) (*bbolt.DB, error) {
+	const mode = 0o755
 	options := bbolt.DefaultOptions
 
 	snapshot := filepath.Join(config.DataPath, "state_snapshot.db")
@@ -201,7 +199,7 @@ func setupStore(config Config, logger hclog.Logger) (*bbolt.DB, error) {
 	case errors.Is(err, os.ErrNotExist):
 		// We don't have a snapshot file waiting to be replaced, so just open the normal store.
 		logger.Debug("no restored snapshots found, opening default store")
-		return bbolt.Open(store, 0o755, options)
+		return bbolt.Open(store, mode, options)
 	case err != nil:
 		return nil, err
 	}
@@ -218,7 +216,7 @@ func setupStore(config Config, logger hclog.Logger) (*bbolt.DB, error) {
 		return nil, err
 	}
 
-	return bbolt.Open(store, 0o755, options)
+	return bbolt.Open(store, mode, options)
 }
 
 // ErrReload is the error given when the server has read a snapshot and must be restarted to restore its state.


### PR DESCRIPTION
This commit allows the operator of a cluster to enable encryption at the serf layer
using an encryption key. This should prevent snooping of the gossip protocol providing
the key isn't exposed.

The encryption key should be stored as a file that contains 16, 24 or 32 bytes which will
select AES-128, AES-192 or AES-256. A make command has been added to generate a sample key
of 32 bytes using /dev/urandom.

Since we now have 2 separate serf files, one for the cluster state and one for the keyring, they
are now placed in their own serf directory within the configurable data path.

Signed-off-by: David Bond <davidsbond93@gmail.com>