### PR TITLE
Make message signing deterministic

### DIFF
--- a/internal/signing/signing.go
+++ b/internal/signing/signing.go
@@ -20,12 +20,14 @@ func NewKeyPair() (public []byte, private []byte, err error) {
 	return pu[:], pb[:], nil
 }
 
-// SignProto encodes the proto.Message and signs it using the private key, returning a signature. The
-// proto-encoding is not deterministic so there is no guarantee that the same message produces the exact same signature.
-// However, it is only important that the signature is verifiable against the public key, so the consistency of the
-// proto-encoding should not matter. Ed25519 is used to sign messages.
+// SignProto encodes the proto.Message and signs it using the private key, returning a signature. Ed25519 is used to
+// sign messages.
 func SignProto(m proto.Message, privateKey []byte) ([]byte, error) {
-	data, err := proto.Marshal(m)
+	options := proto.MarshalOptions{
+		Deterministic: true,
+	}
+
+	data, err := options.Marshal(m)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal message: %w", err)
 	}

--- a/internal/signing/signing_test.go
+++ b/internal/signing/signing_test.go
@@ -26,6 +26,18 @@ func TestSignProto(t *testing.T) {
 		assert.NotEmpty(t, signedMessage)
 	})
 
+	t.Run("The same message should produce the same signature", func(t *testing.T) {
+		expected, err := signing.SignProto(message, privateKey)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, expected)
+
+		for i := 0; i < 100; i++ {
+			actual, err := signing.SignProto(message, privateKey)
+			assert.NoError(t, err)
+			assert.True(t, bytes.Equal(expected, actual))
+		}
+	})
+
 	t.Run("The signed message should be verifiable using the public key", func(t *testing.T) {
 		assert.True(t, signing.Verify(signedMessage, publicKey))
 		assert.False(t, signing.Verify(signedMessage, bytes.Repeat([]byte("a"), 32)))


### PR DESCRIPTION
This commit modifies the proto-message signing so that it uses deterministic marshalling. This
should ensure that the generated signature is always the same so that message integrity can
be guaranteed as well as its provenance.

Signed-off-by: David Bond <davidsbond93@gmail.com>