### PR TITLE
Use gRPC for raft transport

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -45,24 +45,24 @@ func Server() *cobra.Command {
 	flags.DurationVar(&config.PruneInterval, "prune-interval", time.Minute, "The amount of time between message pruning runs")
 
 	// Raft configuration
-	flags.IntVar(&config.Raft.Port, "raft-port", 5000, "The port to use for raft transport")
 	flags.DurationVar(&config.Raft.Timeout, "raft-timeout", time.Minute, "The timeout to use for raft transport")
 	flags.IntVar(&config.Raft.MaxSnapshots, "raft-max-snapshots", 3, "The maximum number of raft snapshots to store")
-	flags.IntVar(&config.Raft.MaxPool, "raft-max-pool", 3, "The maximum number of connections in the raft connection pool")
 	flags.BoolVar(&config.Raft.NonVoter, "raft-non-voter", false, "If true, this server will never obtain leadership and will be a read-only replica")
+
+	// gRPC configuration
+	flags.IntVar(&config.GRPC.Port, "grpc-port", 5000, "The port to use for gRPC transport")
 
 	// Serf configuration
 	flags.IntVar(&config.Serf.Port, "serf-port", 5001, "The port to use for serf transport")
 	flags.StringVar(&config.Serf.EncryptionKeyFile, "serf-encryption-key", "", "The path to the encryption key file used for serf transport")
 
-	// gRPC configuration
-	flags.IntVar(&config.GRPC.Port, "grpc-port", 5002, "The port to use for gRPC transport")
-	flags.StringVar(&config.GRPC.TLSCertFile, "grpc-tls-cert", "", "The location of the TLS cert file for the server to use")
-	flags.StringVar(&config.GRPC.TLSKeyFile, "grpc-tls-key", "", "The location of the TLS key file for the server to use")
-	flags.StringVar(&config.GRPC.TLSCAFile, "grpc-tls-ca", "", "The location of the CA certificate that signs client certificates")
+	// TLS configuration
+	flags.StringVar(&config.TLS.CertFile, "tls-cert", "", "The location of the TLS cert file for the server to use")
+	flags.StringVar(&config.TLS.KeyFile, "tls-key", "", "The location of the TLS key file for the server to use")
+	flags.StringVar(&config.TLS.CAFile, "tls-ca", "", "The location of the CA certificate that signs client certificates")
 
 	// Prometheus configuration
-	flags.IntVar(&config.Metrics.Port, "metrics-port", 5003, "The port to use for serving metrics")
+	flags.IntVar(&config.Metrics.Port, "metrics-port", 5002, "The port to use for serving metrics")
 
 	return cmd
 }

--- a/deploy/kustomize/service.yaml
+++ b/deploy/kustomize/service.yaml
@@ -8,14 +8,10 @@ spec:
     app: arrebato
   ports:
     - port: 5000
-      targetPort: raft
+      targetPort: grpc
       protocol: TCP
-      name: raft
+      name: grpc
     - port: 5001
       targetPort: serf
       protocol: TCP
       name: serf
-    - port: 5002
-      targetPort: grpc
-      protocol: TCP
-      name: grpc

--- a/deploy/kustomize/statefulset.yaml
+++ b/deploy/kustomize/statefulset.yaml
@@ -51,12 +51,10 @@ spec:
               memory: 1Gi
           ports:
             - containerPort: 5000
-              name: raft
+              name: grpc
             - containerPort: 5001
               name: serf
             - containerPort: 5002
-              name: grpc
-            - containerPort: 5003
               name: metrics
           env:
             - name: POD_NAME

--- a/e2e/acl_test.go
+++ b/e2e/acl_test.go
@@ -55,7 +55,7 @@ func (s *ACLSuite) TestACLRulesApply() {
 	})
 
 	s.Run("As a different client, the ACL should not let us produce messages", func() {
-		client, err := arrebato.Dial(ctx, arrebato.DefaultConfig([]string{":5002"}))
+		client, err := arrebato.Dial(ctx, arrebato.DefaultConfig([]string{":5000"}))
 		require.NoError(s.T(), err)
 
 		producer := client.NewProducer(arrebato.ProducerConfig{

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -33,19 +33,17 @@ func (s *Suite) SetupSuite() {
 		DataPath:      tmp,
 		PruneInterval: time.Minute,
 		Raft: server.RaftConfig{
-			Port:         5000,
 			Timeout:      time.Minute,
-			MaxPool:      3,
 			MaxSnapshots: 3,
 		},
 		Serf: server.SerfConfig{
 			Port: 5001,
 		},
 		GRPC: server.GRPCConfig{
-			Port: 5002,
+			Port: 5000,
 		},
 		Metrics: server.MetricConfig{
-			Port: 5003,
+			Port: 5002,
 		},
 	}
 
@@ -67,7 +65,7 @@ func (s *Suite) SetupSuite() {
 	s.cancel = cancel
 	s.client, err = arrebato.Dial(ctx, arrebato.Config{
 		Addresses: []string{
-			":5002",
+			":5000",
 		},
 		ClientID: "test-client",
 	})

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/davidsbond/arrebato
 go 1.18
 
 require (
+	github.com/Jille/raft-grpc-transport v1.2.0
 	github.com/anchore/syft v0.44.0
 	github.com/armon/go-metrics v0.3.10
 	github.com/bufbuild/buf v1.3.1
@@ -260,7 +261,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
-	github.com/hashicorp/go-msgpack v0.5.5 // indirect
+	github.com/hashicorp/go-msgpack v1.1.5 // indirect
 	github.com/hashicorp/go-plugin v1.4.3 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,8 @@ github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 h1:sHglBQTwgx+rW
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
 github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20191009163259-e802c2cb94ae/go.mod h1:mjwGPas4yKduTyubHvD1Atl9r1rUq8DfVy+gkVvZ+oo=
 github.com/GoogleCloudPlatform/cloudsql-proxy v1.27.0/go.mod h1:bn9iHmAjogMoIPkqBGyJ9R1m9cXGCjBE/cuhBs3oEsQ=
+github.com/Jille/raft-grpc-transport v1.2.0 h1:W/YSPz8IsirEyomjKmDog5Xk71o9+l4KhyMEX2TsgSs=
+github.com/Jille/raft-grpc-transport v1.2.0/go.mod h1:GQGUXJfjlzwA390Ox1AyVYpjCLhtGd6yqY9Sb5hpQfc=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
@@ -840,6 +842,7 @@ github.com/facebookincubator/nvdtools v0.1.4/go.mod h1:0/FIVnSEl9YHXLq3tKBPpKaI0
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
+github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/set v0.2.1 h1:nn2CaJyknWE/6txyUDGwysr3G5QC6xWB/PtVjPBbeaA=
@@ -1444,8 +1447,9 @@ github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJ
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-kms-wrapping/entropy v0.1.0/go.mod h1:d1g9WGtAunDNpek8jUIEJnBlbgKS1N2Q61QkHiZyR1g=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
-github.com/hashicorp/go-msgpack v0.5.5 h1:i9R9JSrqIz0QVLz3sz+i3YJdT7TTSLcfLLzJi9aZTuI=
 github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
+github.com/hashicorp/go-msgpack v1.1.5 h1:9byZdVjKTe5mce63pRVNP1L7UAmdHOTEMGehn6KvJWs=
+github.com/hashicorp/go-msgpack v1.1.5/go.mod h1:gWVc3sv/wbDmR3rQsj1CAktEZzoz1YNK9NfGLXJ69/4=
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
@@ -1503,6 +1507,7 @@ github.com/hashicorp/memberlist v0.3.0/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOn
 github.com/hashicorp/memberlist v0.3.1 h1:MXgUXLqva1QvpVEDQW1IQLG0wivQAtmFlHRQ+1vWZfM=
 github.com/hashicorp/memberlist v0.3.1/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/raft v1.1.0/go.mod h1:4Ak7FSPnuvmb0GV6vgIAJ4vYT4bek9bb6Q+7HVbyzqM=
+github.com/hashicorp/raft v1.3.1/go.mod h1:4Ak7FSPnuvmb0GV6vgIAJ4vYT4bek9bb6Q+7HVbyzqM=
 github.com/hashicorp/raft v1.3.7 h1:mnuQAuSMNRjAvFc9IYxnGxZJ9LBBZyheMR8Kv8Ve71M=
 github.com/hashicorp/raft v1.3.7/go.mod h1:4Ak7FSPnuvmb0GV6vgIAJ4vYT4bek9bb6Q+7HVbyzqM=
 github.com/hashicorp/raft-boltdb v0.0.0-20210409134258-03c10cc3d4ea h1:RxcPJuutPRM8PUOyiweMmkuNO+RJyfy2jds2gfvgNmU=
@@ -2788,6 +2793,7 @@ golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210907225631-ff17edfbf26d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210917221730-978cfadd31cf/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211020060615-d418f374d309/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -2968,6 +2974,7 @@ golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210915083310-ed5796bab164/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210917161153-d61c044b1678/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -3037,6 +3044,7 @@ golang.org/x/tools v0.0.0-20190329151228-23e29df326fe/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190416151739-9c9e1878f421/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190420181800-aa740d480789/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190422233926-fe54fb35175b/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190424220101-1e8e1cfdf96b/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=

--- a/internal/clientinfo/clientinfo.go
+++ b/internal/clientinfo/clientinfo.go
@@ -126,3 +126,27 @@ func MetadataExtractor(ctx context.Context) (ClientInfo, error) {
 		ID: strings.Join(values, ""),
 	}, nil
 }
+
+// UnaryClientInterceptor returns a grpc.UnaryClientInterceptor implementation that appends the client identifier to
+// outgoing gRPC metadata under the X-Client-ID key.
+func UnaryClientInterceptor(clientID string) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		if clientID != "" {
+			ctx = metadata.AppendToOutgoingContext(ctx, "X-Client-ID", clientID)
+		}
+
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+// StreamClientInterceptor returns a grpc.StreamClientInterceptor implementation that appends the client identifier to
+// outgoing gRPC metadata under the X-Client-ID key.
+func StreamClientInterceptor(clientID string) grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		if clientID != "" {
+			ctx = metadata.AppendToOutgoingContext(ctx, "X-Client-ID", clientID)
+		}
+
+		return streamer(ctx, desc, cc, method, opts...)
+	}
+}

--- a/internal/server/serf.go
+++ b/internal/server/serf.go
@@ -30,7 +30,6 @@ type (
 
 const (
 	voterKey            = "voter"
-	raftPortKey         = "raft_port"
 	grpcPortKey         = "grpc_port"
 	roleKey             = "role"
 	advertiseAddressKey = "advertise_address"
@@ -86,7 +85,6 @@ func setupSerf(config Config, logger hclog.Logger) (<-chan serf.Event, *serf.Ser
 	serfConfig.RejoinAfterLeave = true
 	serfConfig.Tags = map[string]string{
 		voterKey:            strconv.FormatBool(!config.Raft.NonVoter),
-		raftPortKey:         strconv.Itoa(config.Raft.Port),
 		grpcPortKey:         strconv.Itoa(config.GRPC.Port),
 		advertiseAddressKey: config.AdvertiseAddress,
 		roleKey:             "server",
@@ -184,7 +182,7 @@ func (svr *Server) handleSerfEventMemberJoin(ctx context.Context, event serf.Mem
 
 		var err error
 		voter := isVoter(member.Tags)
-		peer := net.JoinHostPort(member.Tags[advertiseAddressKey], member.Tags[raftPortKey])
+		peer := net.JoinHostPort(member.Tags[advertiseAddressKey], member.Tags[grpcPortKey])
 
 		if voter {
 			err = svr.raft.AddVoter(serverID, raft.ServerAddress(peer), 0, svr.config.Raft.Timeout).Error()


### PR DESCRIPTION
This commit modifies the server code to use the gRPC layer for raft transport. This means that
we can use one less port and take advantage of the existing TLS setup for the gRPC server. Now,
inter-node communication can be encrypted.

Signed-off-by: David Bond <davidsbond93@gmail.com>