### PR TITLE
Create github actions workflow that automatically keeps distroless/static up-to-date

### DIFF
--- a/.github/workflows/distroless.yml
+++ b/.github/workflows/distroless.yml
@@ -1,0 +1,23 @@
+name: distroless
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 12 * * *'
+
+jobs:
+  update:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Update base image
+        run: make update-distroless
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: Update Distroless base image
+          commit-message: |
+            This commit updates the gcr.io/distroless/static digest to the latest known version
+          body: |
+            This commit updates the gcr.io/distroless/static digest to the latest known version
+          labels: dependencies,docker

--- a/Makefile
+++ b/Makefile
@@ -88,3 +88,6 @@ generate-serf-key:
 
 kubeval: kustomize
 	kubeval install.yaml
+
+update-distroless:
+	./scripts/update_distroless.sh

--- a/scripts/update_distroless.sh
+++ b/scripts/update_distroless.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+docker pull gcr.io/distroless/static
+
+LATEST_DIGEST=$(docker images --format '{{json .}}' --digests gcr.io/distroless/static | jq -r 'select (.Tag=="latest") | .Digest')
+CURRENT_DIGEST=$(cat Dockerfile | grep FROM | awk -F'@' '{print $2}')
+
+if [ "$LATEST_DIGEST" != "$CURRENT_DIGEST" ]; then
+  sed -i "s/$CURRENT_DIGEST/$LATEST_DIGEST/" Dockerfile
+fi


### PR DESCRIPTION
This commit introduces a github actions workflow and script that can replace the current
digest of the gcr.io/distroless/static image with the latest one pulled from the repository.

This workflow will run on a cronjob and open a pull request with the update.

Signed-off-by: David Bond <davidsbond93@gmail.com>