### PR TITLE
Include tools directory in dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: gomod
+    directory: /tools
+    schedule:
+      interval: daily
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
This commit updates the dependabot configuration to include the new go module within
the `tools` directory. This should allow for dependency upgrades for tooling.

Signed-off-by: David Bond <davidsbond93@gmail.com>