### PR TITLE
Modify goreleaser configuration for more architectures

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,13 +14,18 @@ builds:
       - "-s -w -X main.version={{ .Version }}"
     goos:
       - linux
+      - windows
+      - darwin
+      - freebsd
     goarch:
       - amd64
       - arm64
+      - arm
+      - "386"
+    ignore:
+      - goos: darwin
+        goarch: "386"
     binary: "{{ .ProjectName }}"
-    hooks:
-      post:
-        - upx -qq {{ .Path }}
 
 dockers:
   - id: linux_amd64


### PR DESCRIPTION
This commit modifies the goreleaser configuration to produce binaries for all the major
os/architecture combinations, including windows, darwin & freebsd.

A negative side-effect is not being able to use UPX for everything, so this has been
removed for now. Binaries are still only about 15mb which isn't substantial, but it
would be nice in future to get back to 5mb binaries.

Signed-off-by: David Bond <davidsbond93@gmail.com>