### PR TITLE
Ensure we skip all raft logs we've already processed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 *.upx
 serf.key
 /licenses
+_example/

--- a/internal/server/raft.go
+++ b/internal/server/raft.go
@@ -232,7 +232,7 @@ func (svr *Server) Apply(log *raft.Log) interface{} {
 	// the state so if the log index is less than the last known index sent to the FSM then we do nothing. We can't
 	// fully rely on the raft mechanism to know exactly the last log index that the FSM successfully handled, so we
 	// also track that manually.
-	if log.Index < lastAppliedIndex && lastAppliedIndex != 0 {
+	if log.Index <= lastAppliedIndex && lastAppliedIndex != 0 {
 		return nil
 	}
 


### PR DESCRIPTION
This commit modifies the check for the last applied index to be a less than or
equal to comparison. Otherwise, the very last item in the raft log could be
replayed, leading to a duplicate message.

Signed-off-by: David Bond <davidsbond93@gmail.com>