### PR TITLE
Include root CAs in tls configuration

### DIFF
--- a/internal/server/tls.go
+++ b/internal/server/tls.go
@@ -43,6 +43,7 @@ func (c TLSConfig) tlsConfig() (*tls.Config, error) {
 		Certificates: []tls.Certificate{cert},
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		ClientCAs:    certPool,
+		RootCAs:      certPool,
 		MinVersion:   tls.VersionTLS13,
 	}, nil
 }


### PR DESCRIPTION
When previously refactoring, I missed setting the RootCAs field which will be used
by clients.

Signed-off-by: David Bond <davidsbond93@gmail.com>