### PR TITLE
Add CLI command for deleting topics

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,9 +2,11 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -121,4 +123,22 @@ func closeIt(c io.Closer) {
 	if err := c.Close(); err != nil {
 		hclog.Default().Error("failed to close", "error", err)
 	}
+}
+
+func confirmf(input io.Reader, output io.Writer, prompt string, args ...interface{}) (bool, error) {
+	r := bufio.NewReader(input)
+
+	fmt.Fprintf(output, prompt, args...)
+	fmt.Fprint(output, " [y/N]: ")
+
+	value, err := r.ReadString('\n')
+	if err != nil {
+		return false, fmt.Errorf("failed to read input: %w", err)
+	}
+
+	if len(value) < 2 {
+		return false, nil
+	}
+
+	return strings.ToLower(strings.TrimSpace(value))[0] == 'y', nil
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"context"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/davidsbond/arrebato/pkg/arrebato"
+)
+
+// Delete returns a command for deleting various server resources.
+func Delete() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete server resources (topics, etc.)",
+		Long:  "This command is the parent command for deleting server resources",
+	}
+
+	cmd.AddCommand(
+		deleteTopic(),
+	)
+
+	return cmd
+}
+
+func deleteTopic() *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:               "topic [flags] <name>",
+		Short:             "Deletes a topic",
+		Long:              "This command deletes a topic from the server and all its messages",
+		Args:              cobra.ExactValidArgs(1),
+		ValidArgsFunction: validTopicNames,
+		RunE: withClient(func(ctx context.Context, client *arrebato.Client, args []string) error {
+			if force {
+				return client.DeleteTopic(ctx, args[0])
+			}
+
+			ok, err := confirmf(os.Stdin, os.Stdout, "Are you sure you want to delete topic %s?", args[0])
+			switch {
+			case err != nil:
+				return err
+			case !ok:
+				return nil
+			default:
+				return client.DeleteTopic(ctx, args[0])
+			}
+		}),
+	}
+
+	flags := cmd.PersistentFlags()
+	flags.BoolVar(&force, "force", false, "Do not prompt for confirmation")
+
+	return cmd
+}

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func main() {
 		cmd.List(),
 		cmd.Describe(),
 		cmd.Backup(),
+		cmd.Delete(),
 	)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)


### PR DESCRIPTION
This commit adds a CLI command that allows an operator to delete a topic from the
command-line. It prompts the user for confirmation and supports a force flag which
will disable confirmation when provided.

Signed-off-by: David Bond <davidsbond93@gmail.com>