### PR TITLE
Expose available topics via node service

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -85,6 +85,7 @@ func describeNode() *cobra.Command {
 			fmt.Println("Leader:", node.Leader)
 			fmt.Println("Version:", node.Version)
 			fmt.Println("Peers:", len(node.Peers))
+			fmt.Println("Topics:", len(node.Topics))
 
 			return nil
 		}),

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -110,9 +110,9 @@ func listNodes() *cobra.Command {
 				return json.NewEncoder(os.Stdout).Encode(nodes)
 			}
 
-			builder := table.NewBuilder("NAME", "LEADER", "VERSION")
+			builder := table.NewBuilder("NAME", "LEADER", "VERSION", "TOPICS")
 			for _, n := range nodes {
-				builder.AddRow(n.Name, n.Leader, n.Version)
+				builder.AddRow(n.Name, n.Leader, n.Version, len(n.Topics))
 			}
 
 			return builder.Build(ctx, os.Stdout)

--- a/internal/node/grpc_test.go
+++ b/internal/node/grpc_test.go
@@ -1,10 +1,13 @@
 package node_test
 
 import (
+	"io"
 	"testing"
 
 	"github.com/hashicorp/raft"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/davidsbond/arrebato/internal/node"
@@ -17,22 +20,23 @@ func TestGRPC_Describe(t *testing.T) {
 	t.Parallel()
 
 	tt := []struct {
-		Name     string
-		State    raft.RaftState
-		Config   raft.Configuration
-		Expected *nodesvc.DescribeResponse
+		Name         string
+		State        raft.RaftState
+		Nodes        []*nodepb.Node
+		Error        error
+		ExpectedCode codes.Code
+		Expected     *nodesvc.DescribeResponse
 	}{
 		{
 			Name:  "It should return node details and known peers",
 			State: raft.Leader,
-			Config: raft.Configuration{
-				Servers: []raft.Server{
-					{
-						ID: raft.ServerID("test-server"),
-					},
-					{
-						ID: raft.ServerID("test-server-2"),
-					},
+			Nodes: []*nodepb.Node{
+				{
+					Name:   "test-server",
+					Topics: []string{"test-topic"},
+				},
+				{
+					Name: "test-server-2",
 				},
 			},
 			Expected: &nodesvc.DescribeResponse{
@@ -41,21 +45,35 @@ func TestGRPC_Describe(t *testing.T) {
 					Leader:  true,
 					Peers:   []string{"test-server-2"},
 					Version: "v1.0.0",
+					Topics:  []string{"test-topic"},
 				},
 			},
+		},
+		{
+			Name:         "It should return errors to the caller",
+			Error:        io.EOF,
+			ExpectedCode: codes.Internal,
 		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
 			ctx := testutil.Context(t)
-			r := &MockRaft{state: tc.State, config: tc.Config}
+			r := &MockRaft{state: tc.State}
+			lister := &MockLister{nodes: tc.Nodes, err: tc.Error}
 			info := node.Info{
-				LocalID: raft.ServerID("test-server"),
+				Name:    "test-server",
 				Version: "v1.0.0",
 			}
 
-			actual, err := node.NewGRPC(r, info, nil).Describe(ctx, &nodesvc.DescribeRequest{})
+			actual, err := node.NewGRPC(r, info, nil, lister).Describe(ctx, &nodesvc.DescribeRequest{})
+			assert.Equal(t, tc.ExpectedCode, status.Code(err))
+
+			if tc.Error != nil {
+				assert.Error(t, err)
+				return
+			}
+
 			assert.NoError(t, err)
 			assert.True(t, proto.Equal(tc.Expected, actual))
 		})

--- a/internal/node/mocks_test.go
+++ b/internal/node/mocks_test.go
@@ -10,21 +10,23 @@ import (
 
 type (
 	MockRaft struct {
-		state  raft.RaftState
-		config raft.Configuration
-	}
-
-	MockConfigurationFuture struct {
-		raft.ConfigurationFuture
-
-		config raft.Configuration
+		state raft.RaftState
 	}
 
 	MockStore struct {
 		saved *node.Node
 		err   error
 	}
+
+	MockLister struct {
+		nodes []*node.Node
+		err   error
+	}
 )
+
+func (mm *MockLister) List(ctx context.Context) ([]*node.Node, error) {
+	return mm.nodes, mm.err
+}
 
 func (mm *MockStore) AssignTopic(ctx context.Context, nodeName, topicName string) error {
 	return mm.err
@@ -39,18 +41,6 @@ func (mm *MockStore) Delete(ctx context.Context, name string) error {
 	return mm.err
 }
 
-func (mm *MockRaft) GetConfiguration() raft.ConfigurationFuture {
-	return &MockConfigurationFuture{config: mm.config}
-}
-
 func (mm *MockRaft) State() raft.RaftState {
 	return mm.state
-}
-
-func (mm *MockConfigurationFuture) Error() error {
-	return nil
-}
-
-func (mm *MockConfigurationFuture) Configuration() raft.Configuration {
-	return mm.config
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -161,10 +161,10 @@ func New(config Config) (*Server, error) {
 	server.executor = command.NewExecutor(server.raft, config.Raft.Timeout)
 
 	// Node stack
-	info := node.Info{LocalID: raft.ServerID(config.AdvertiseAddress), Version: config.Version}
+	info := node.Info{Name: config.AdvertiseAddress, Version: config.Version}
 	server.nodeStore = node.NewBoltStore(server.store)
 	server.nodeHandler = node.NewHandler(server.nodeStore, server.logger)
-	server.nodeGRPC = node.NewGRPC(server.raft, info, backup.NewBoltDB(server.store))
+	server.nodeGRPC = node.NewGRPC(server.raft, info, backup.NewBoltDB(server.store), server.nodeStore)
 
 	// ACL stack
 	server.aclStore = acl.NewBoltStore(server.store)

--- a/internal/topic/handler.go
+++ b/internal/topic/handler.go
@@ -41,6 +41,7 @@ func (h *Handler) Create(ctx context.Context, cmd *topiccmd.CreateTopic) error {
 		"name", cmd.GetTopic().GetName(),
 		"message_retention_period", cmd.GetTopic().GetMessageRetentionPeriod().AsDuration(),
 		"consumer_retention_period", cmd.GetTopic().GetConsumerRetentionPeriod().AsDuration(),
+		"require_verified_messages", cmd.GetTopic().GetRequireVerifiedMessages(),
 	)
 
 	return nil

--- a/pkg/arrebato/node.go
+++ b/pkg/arrebato/node.go
@@ -20,6 +20,8 @@ type (
 		Version string `json:"version"`
 		// Peers known to the node
 		Peers []string `json:"peers"`
+		// Topics assigned to the node
+		Topics []string `json:"topics"`
 	}
 )
 
@@ -37,6 +39,7 @@ func (c *Client) Nodes(ctx context.Context) ([]Node, error) {
 			Leader:  resp.GetNode().GetLeader(),
 			Version: resp.GetNode().GetVersion(),
 			Peers:   resp.GetNode().GetPeers(),
+			Topics:  resp.GetNode().GetTopics(),
 		})
 
 		return nil
@@ -65,5 +68,6 @@ func (c *Client) Node(ctx context.Context, name string) (Node, error) {
 		Leader:  resp.GetNode().GetLeader(),
 		Version: resp.GetNode().GetVersion(),
 		Peers:   resp.GetNode().GetPeers(),
+		Topics:  resp.GetNode().GetTopics(),
 	}, nil
 }


### PR DESCRIPTION
This commit modifies the node gRPC service to obtain peer and topic data from
the internal store rather than the raft configuration. Clients will be able to
use this to know which node to go to for each topic.

Signed-off-by: David Bond <davidsbond93@gmail.com>