### PR TITLE
Ensure topics are balanced and rebalanced

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,8 @@ services:
       - server
       - --log-level=2
       - --advertise-address=arrebato-0
+    ports:
+      - "5000:5000"
     networks:
       - default
 
@@ -22,6 +24,8 @@ services:
       - --peers=arrebato-0
       - --log-level=2
       - --advertise-address=arrebato-1
+    ports:
+      - "5001:5000"
     depends_on:
       - arrebato-0
     networks:
@@ -37,6 +41,8 @@ services:
       - --peers=arrebato-0
       - --log-level=2
       - --advertise-address=arrebato-2
+    ports:
+      - "5002:5000"
     depends_on:
       - arrebato-1
     networks:

--- a/internal/node/grpc.go
+++ b/internal/node/grpc.go
@@ -4,6 +4,7 @@ package node
 import (
 	"context"
 	"io"
+	"sort"
 	"time"
 
 	"github.com/hashicorp/raft"
@@ -81,6 +82,10 @@ func (svr *GRPC) Describe(ctx context.Context, _ *nodesvc.DescribeRequest) (*nod
 
 		peers = append(peers, n.GetName())
 	}
+
+	sort.Slice(topics, func(i, j int) bool {
+		return topics[i] < topics[j]
+	})
 
 	return &nodesvc.DescribeResponse{
 		Node: &node.Node{

--- a/internal/server/raft.go
+++ b/internal/server/raft.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	transport "github.com/Jille/raft-grpc-transport"
@@ -411,16 +412,9 @@ func (svr *Server) pickNodeWithLeastTopics(ctx context.Context) (*nodepb.Node, e
 		return nil, err
 	}
 
-	var selected *nodepb.Node
-	for _, n := range nodes {
-		if len(n.GetTopics()) <= len(selected.GetTopics()) {
-			selected = n
-		}
-	}
+	sort.Slice(nodes, func(i, j int) bool {
+		return len(nodes[i].GetTopics()) < len(nodes[j].GetTopics())
+	})
 
-	if selected == nil {
-		selected = nodes[0]
-	}
-
-	return selected, nil
+	return nodes[0], nil
 }

--- a/internal/server/serf.go
+++ b/internal/server/serf.go
@@ -258,6 +258,10 @@ func (svr *Server) handleSerfEventMemberLeave(ctx context.Context, event serf.Me
 		}
 	}
 
+	if svr.IsLeader() {
+		return svr.ensureTopicsAreAssigned(ctx)
+	}
+
 	return nil
 }
 

--- a/pkg/arrebato/node.go
+++ b/pkg/arrebato/node.go
@@ -3,6 +3,7 @@ package arrebato
 import (
 	"context"
 	"errors"
+	"sort"
 
 	"google.golang.org/grpc"
 
@@ -45,6 +46,10 @@ func (c *Client) Nodes(ctx context.Context) ([]Node, error) {
 		return nil
 	})
 
+	sort.Slice(nodes, func(i, j int) bool {
+		return nodes[i].Name < nodes[j].Name
+	})
+	
 	return nodes, err
 }
 

--- a/pkg/arrebato/node.go
+++ b/pkg/arrebato/node.go
@@ -49,7 +49,7 @@ func (c *Client) Nodes(ctx context.Context) ([]Node, error) {
 	sort.Slice(nodes, func(i, j int) bool {
 		return nodes[i].Name < nodes[j].Name
 	})
-	
+
 	return nodes, err
 }
 

--- a/pkg/arrebato/signing.go
+++ b/pkg/arrebato/signing.go
@@ -3,6 +3,7 @@ package arrebato
 import (
 	"context"
 	"errors"
+	"sort"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -84,6 +85,10 @@ func (c *Client) PublicKeys(ctx context.Context) ([]PublicKey, error) {
 			PublicKey: k.GetPublicKey(),
 		}
 	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ClientID < out[j].ClientID
+	})
 
 	return out, nil
 }

--- a/pkg/arrebato/topic.go
+++ b/pkg/arrebato/topic.go
@@ -3,6 +3,7 @@ package arrebato
 import (
 	"context"
 	"errors"
+	"sort"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -101,6 +102,10 @@ func (c *Client) Topics(ctx context.Context) ([]Topic, error) {
 			RequireVerifiedMessages: tp.GetRequireVerifiedMessages(),
 		}
 	}
+
+	sort.Slice(topics, func(i, j int) bool {
+		return topics[i].Name < topics[j].Name
+	})
 
 	return topics, nil
 }


### PR DESCRIPTION
These commits modify the raft and serf logic so that topics are rebalanced across nodes in the event that
leadership changes or a node leaves the cluster.

Related to #85 