### PR TITLE
Unassign topics when they are deleted

### DIFF
--- a/internal/node/handler.go
+++ b/internal/node/handler.go
@@ -22,6 +22,7 @@ type (
 		Create(ctx context.Context, n *node.Node) error
 		Delete(ctx context.Context, name string) error
 		AssignTopic(ctx context.Context, nodeName, topicName string) error
+		UnassignTopic(ctx context.Context, topicName string) error
 	}
 )
 
@@ -60,5 +61,15 @@ func (h *Handler) AssignTopic(ctx context.Context, payload *nodecmd.AssignTopic)
 	}
 
 	h.logger.Debug("assigned topic", "node_name", payload.GetNodeName(), "topic_name", payload.GetTopicName())
+	return nil
+}
+
+// UnassignTopic unassigns a topic from any nodes it may be assigned to.
+func (h *Handler) UnassignTopic(ctx context.Context, payload *nodecmd.UnassignTopic) error {
+	if err := h.nodes.UnassignTopic(ctx, payload.GetName()); err != nil {
+		return fmt.Errorf("failed to handle command: %w", err)
+	}
+
+	h.logger.Debug("unassigned topic", "topic_name", payload.GetName())
 	return nil
 }

--- a/internal/node/handler_test.go
+++ b/internal/node/handler_test.go
@@ -147,3 +147,44 @@ func TestHandler_AssignTopic(t *testing.T) {
 		})
 	}
 }
+
+func TestHandler_UnassignTopic(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		Name         string
+		Error        error
+		ExpectsError bool
+		Command      *nodecmd.UnassignTopic
+	}{
+		{
+			Name: "It should unassign a topic from a node",
+			Command: &nodecmd.UnassignTopic{
+				Name: "test",
+			},
+		},
+		{
+			Name:         "It should propagate errors",
+			Error:        io.EOF,
+			ExpectsError: true,
+			Command: &nodecmd.UnassignTopic{
+				Name: "test",
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			store := &MockStore{err: tc.Error}
+			ctx := testutil.Context(t)
+
+			err := node.NewHandler(store, hclog.NewNullLogger()).UnassignTopic(ctx, tc.Command)
+			if tc.ExpectsError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/internal/node/mocks_test.go
+++ b/internal/node/mocks_test.go
@@ -24,6 +24,10 @@ type (
 	}
 )
 
+func (mm *MockStore) UnassignTopic(ctx context.Context, topicName string) error {
+	return mm.err
+}
+
 func (mm *MockLister) List(ctx context.Context) ([]*node.Node, error) {
 	return mm.nodes, mm.err
 }

--- a/internal/node/store_test.go
+++ b/internal/node/store_test.go
@@ -131,3 +131,27 @@ func TestBoltStore_GetTopicOwner(t *testing.T) {
 		assert.Nil(t, result)
 	})
 }
+
+func TestBoltStore_UnassignTopic(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t)
+	db := testutil.BoltDB(t)
+	store := node.NewBoltStore(db)
+
+	// Create a node to assign topics to
+	require.NoError(t, store.Create(ctx, &nodepb.Node{
+		Name: "node-0",
+	}))
+
+	// Assign a topic to a node
+	const topicName = "topic-0"
+	const nodeName = "node-0"
+	require.NoError(t, store.AssignTopic(ctx, nodeName, topicName))
+
+	t.Run("It should unassign a topic from a node", func(t *testing.T) {
+		require.NoError(t, store.UnassignTopic(ctx, topicName))
+		_, err := store.GetTopicOwner(ctx, topicName)
+		assert.Error(t, err)
+	})
+}

--- a/internal/proto/arrebato/node/command/v1/command.pb.go
+++ b/internal/proto/arrebato/node/command/v1/command.pb.go
@@ -176,6 +176,55 @@ func (x *AssignTopic) GetTopicName() string {
 	return ""
 }
 
+// The UnassignTopic message is a command indicating that a topic should be unassigned from all nodes. For example,
+// if it is deleted.
+type UnassignTopic struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+}
+
+func (x *UnassignTopic) Reset() {
+	*x = UnassignTopic{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_arrebato_node_command_v1_command_proto_msgTypes[3]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *UnassignTopic) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnassignTopic) ProtoMessage() {}
+
+func (x *UnassignTopic) ProtoReflect() protoreflect.Message {
+	mi := &file_arrebato_node_command_v1_command_proto_msgTypes[3]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnassignTopic.ProtoReflect.Descriptor instead.
+func (*UnassignTopic) Descriptor() ([]byte, []int) {
+	return file_arrebato_node_command_v1_command_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *UnassignTopic) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
 var File_arrebato_node_command_v1_command_proto protoreflect.FileDescriptor
 
 var file_arrebato_node_command_v1_command_proto_rawDesc = []byte{
@@ -195,12 +244,15 @@ var file_arrebato_node_command_v1_command_proto_rawDesc = []byte{
 	0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x6e, 0x6f, 0x64, 0x65,
 	0x4e, 0x61, 0x6d, 0x65, 0x12, 0x1d, 0x0a, 0x0a, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x5f, 0x6e, 0x61,
 	0x6d, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x74, 0x6f, 0x70, 0x69, 0x63, 0x4e,
-	0x61, 0x6d, 0x65, 0x42, 0x50, 0x5a, 0x4e, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f,
-	0x6d, 0x2f, 0x64, 0x61, 0x76, 0x69, 0x64, 0x73, 0x62, 0x6f, 0x6e, 0x64, 0x2f, 0x61, 0x72, 0x72,
-	0x65, 0x62, 0x61, 0x74, 0x6f, 0x2f, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c, 0x2f, 0x70,
-	0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x61, 0x72, 0x72, 0x65, 0x62, 0x61, 0x74, 0x6f, 0x2f, 0x6e, 0x6f,
-	0x64, 0x65, 0x2f, 0x63, 0x6f, 0x6d, 0x6d, 0x61, 0x6e, 0x64, 0x2f, 0x76, 0x31, 0x3b, 0x6e, 0x6f,
-	0x64, 0x65, 0x63, 0x6d, 0x64, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x61, 0x6d, 0x65, 0x22, 0x23, 0x0a, 0x0d, 0x55, 0x6e, 0x61, 0x73, 0x73, 0x69, 0x67, 0x6e, 0x54,
+	0x6f, 0x70, 0x69, 0x63, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01,
+	0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x42, 0x50, 0x5a, 0x4e, 0x67, 0x69, 0x74, 0x68,
+	0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x64, 0x61, 0x76, 0x69, 0x64, 0x73, 0x62, 0x6f, 0x6e,
+	0x64, 0x2f, 0x61, 0x72, 0x72, 0x65, 0x62, 0x61, 0x74, 0x6f, 0x2f, 0x69, 0x6e, 0x74, 0x65, 0x72,
+	0x6e, 0x61, 0x6c, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x61, 0x72, 0x72, 0x65, 0x62, 0x61,
+	0x74, 0x6f, 0x2f, 0x6e, 0x6f, 0x64, 0x65, 0x2f, 0x63, 0x6f, 0x6d, 0x6d, 0x61, 0x6e, 0x64, 0x2f,
+	0x76, 0x31, 0x3b, 0x6e, 0x6f, 0x64, 0x65, 0x63, 0x6d, 0x64, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74,
+	0x6f, 0x33,
 }
 
 var (
@@ -215,15 +267,16 @@ func file_arrebato_node_command_v1_command_proto_rawDescGZIP() []byte {
 	return file_arrebato_node_command_v1_command_proto_rawDescData
 }
 
-var file_arrebato_node_command_v1_command_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_arrebato_node_command_v1_command_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_arrebato_node_command_v1_command_proto_goTypes = []interface{}{
-	(*AddNode)(nil),     // 0: arrebato.node.command.v1.AddNode
-	(*RemoveNode)(nil),  // 1: arrebato.node.command.v1.RemoveNode
-	(*AssignTopic)(nil), // 2: arrebato.node.command.v1.AssignTopic
-	(*v1.Node)(nil),     // 3: arrebato.node.v1.Node
+	(*AddNode)(nil),       // 0: arrebato.node.command.v1.AddNode
+	(*RemoveNode)(nil),    // 1: arrebato.node.command.v1.RemoveNode
+	(*AssignTopic)(nil),   // 2: arrebato.node.command.v1.AssignTopic
+	(*UnassignTopic)(nil), // 3: arrebato.node.command.v1.UnassignTopic
+	(*v1.Node)(nil),       // 4: arrebato.node.v1.Node
 }
 var file_arrebato_node_command_v1_command_proto_depIdxs = []int32{
-	3, // 0: arrebato.node.command.v1.AddNode.node:type_name -> arrebato.node.v1.Node
+	4, // 0: arrebato.node.command.v1.AddNode.node:type_name -> arrebato.node.v1.Node
 	1, // [1:1] is the sub-list for method output_type
 	1, // [1:1] is the sub-list for method input_type
 	1, // [1:1] is the sub-list for extension type_name
@@ -273,6 +326,18 @@ func file_arrebato_node_command_v1_command_proto_init() {
 				return nil
 			}
 		}
+		file_arrebato_node_command_v1_command_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*UnassignTopic); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -280,7 +345,7 @@ func file_arrebato_node_command_v1_command_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_arrebato_node_command_v1_command_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   3,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/server/raft.go
+++ b/internal/server/raft.go
@@ -252,6 +252,8 @@ func (svr *Server) Apply(log *raft.Log) interface{} {
 		err = svr.nodeHandler.Remove(ctx, payload)
 	case *nodecmd.AssignTopic:
 		err = svr.nodeHandler.AssignTopic(ctx, payload)
+	case *nodecmd.UnassignTopic:
+		err = svr.nodeHandler.UnassignTopic(ctx, payload)
 	default:
 		break
 	}

--- a/proto/arrebato/node/command/v1/command.proto
+++ b/proto/arrebato/node/command/v1/command.proto
@@ -23,3 +23,9 @@ message AssignTopic {
   string node_name = 1;
   string topic_name = 2;
 }
+
+// The UnassignTopic message is a command indicating that a topic should be unassigned from all nodes. For example,
+// if it is deleted.
+message UnassignTopic {
+  string name = 1;
+}


### PR DESCRIPTION
This commit modifies the topic assignment mechanism to unassign topics from any
nodes when a topic is deleted. This was missed from the original topic assignment
implementation.

Signed-off-by: David Bond <davidsbond93@gmail.com>